### PR TITLE
Returns None if desc is NULL

### DIFF
--- a/av/data/stream.pyx
+++ b/av/data/stream.pyx
@@ -30,6 +30,8 @@ cdef class DataStream(Stream):
     property name:
         def __get__(self):
             desc = lib.avcodec_descriptor_get(self._codec_context.codec_id)
+            if desc == NULL:
+                return None
             return desc.name
 
     property type:


### PR DESCRIPTION
avcodec_descriptor_get() returns NULL when no descriptor exists.
https://ffmpeg.org/doxygen/3.2/group__lavc__misc.html#gac09f8ddc2d4b36c5a85c6befba0d0888